### PR TITLE
Add blockr.ui to Remotes (fix GitHub-only dep resolution)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,6 @@ Imports:
     gt
 Suggests:
     testthat (>= 3.0.0)
+Remotes:
+    BristolMyersSquibb/blockr.ui
 Config/testthat/edition: 3


### PR DESCRIPTION
blockr.extra imports `blockr.ui`, which is **GitHub-only** (not published on CRAN). When the full dependency closure is resolved with pak — e.g. in `blockr.sandbox` production deploys — the solve fails with:

```
! Could not solve package dependencies:
* deps::...: dependency conflict
```

The underlying cause is `blockr.ui resolution failed`: pak looks for `blockr.ui` on CRAN (because nothing maps it to GitHub here) and can't find it. `Remotes` are **not** inherited from parent packages, so every package that imports a GitHub-only blockr dep must pin it in its own `Remotes`.

This adds the one missing pin:

```
Remotes:
    BristolMyersSquibb/blockr.ui
```

`blockr.core` / `blockr.dplyr` are also imported but **are** on CRAN, and pak unifies those to the GitHub dev versions when another package in the closure pins them — so they don't need a Remote here. Verified: with this change the `blockr.sandbox` closure resolves cleanly (145 pkgs, OK).